### PR TITLE
ADD: `read_trmm`-function to io_func.py

### DIFF
--- a/notebooks/match3d/io_func.py
+++ b/notebooks/match3d/io_func.py
@@ -91,6 +91,110 @@ def read_gpm(filename):
     return gpm_data
 
 
+def read_trmm(filename1, filename2):
 
+    # trmm 2A23 and 2A25 data is hdf4
+    # it can be read with `read_generic_netcdf`
+    pr_data1 = wrl.io.read_generic_netcdf(filename1)
+    pr_data2 = wrl.io.read_generic_netcdf(filename2)
 
+    lon = pr_data1['variables']['Longitude']['data']
+    lat = pr_data1['variables']['Latitude']['data']
 
+    year = pr_data1['variables']['Year']['data']
+    month = pr_data1['variables']['Month']['data']
+    dayofmonth = pr_data1['variables']['DayOfMonth']['data']
+    dayofyear = pr_data1['variables']['DayOfYear']['data']
+    hour = pr_data1['variables']['Hour']['data']
+    minute = pr_data1['variables']['Minute']['data']
+    second = pr_data1['variables']['Second']['data']
+    secondofday = pr_data1['variables']['scanTime_sec']['data']
+    millisecond = pr_data1['variables']['MilliSecond']['data']
+    date_array = zip(year, month, dayofmonth,
+                     hour, minute, second,
+                     millisecond.astype(np.int32) * 1000)
+    pr_time = np.array(
+        [dt.datetime(d[0], d[1], d[2], d[3], d[4], d[5], d[6]) for d in
+         date_array])
+
+    pflag = pr_data1['variables']['rainFlag']['data']
+    ptype = pr_data1['variables']['rainType']['data']
+
+    status = pr_data1['variables']['status']['data']
+    zbb = pr_data1['variables']['HBB']['data']
+    bbwidth = pr_data1['variables']['BBwidth']['data']
+
+    quality = pr_data2['variables']['dataQuality']['data']
+    refl = pr_data2['variables']['correctZFactor']['data']
+
+    # Check for bad data
+    if max(quality) != 0:
+        raise ValueError('TRMM contains Bad Data')
+
+    # Determine the dimensions
+    ndim = refl.ndim
+    if ndim != 3:
+        raise ValueError('TRMM Dimensions do not match! Needed 3, given {0}'.format(ndim))
+
+    tmp = refl.shape
+    nscan = tmp[0]
+    nray = tmp[1]
+    nbin = tmp[2]
+
+    # Reverse direction along the beam
+    # TODO: Why is this reversed?
+    refl = refl[::-1]
+
+    # Simplify the precipitation flag
+    ipos = (pflag >= 10) & (pflag <= 20)
+    icer = (pflag >= 20)
+    pflag[ipos] = 1
+    pflag[icer] = 2
+
+    # Simplify the precipitation types
+    istr = (ptype >= 100) & (ptype <= 200)
+    icon = (ptype >= 200) & (ptype <= 300)
+    ioth = (ptype >= 300)
+    inone = (ptype == -88)
+    imiss = (ptype == -99)
+    ptype[istr] = 1
+    ptype[icon] = 2
+    ptype[ioth] = 3
+    ptype[inone] = 0
+    ptype[imiss] = -1
+
+    # Extract the surface type
+    sfc = np.zeros((nscan, nray), dtype=np.uint8)
+    i0 = (status == 168)
+    sfc[i0] = 0
+    i1 = (status % 10 == 0)
+    sfc[i1] = 1
+    i2 = ((status - 1) % 10 == 0)
+    sfc[i2] = 2
+    i3 = ((status - 3) % 10 == 0)
+    sfc[i3] = 3
+    i4 = ((status - 4)  % 10 == 0)
+    sfc[i4] = 4
+    i5 = ((status - 5) % 10 == 0)
+    sfc[i5] = 5
+    i9 = ((status - 9) % 10 == 0)
+    sfc[i9] = 9
+
+    # Extract 2A23 quality
+    # TODO: Why is the `quality` variable overwritten?
+    quality = np.zeros((nscan, nray), dtype=np.uint8)
+    i0 = (status == 168)
+    sfc[i0] = 0
+    i1 = (status  <  50)
+    sfc[i1] = 1
+    i2 = ((status >= 50) & (status < 109))
+    sfc[i2] = 2
+
+    trmm_data = {}
+    trmm_data.update({'nscan': nscan, 'nray': nray, 'nbin': nbin,
+                     'date': pr_time, 'lon': lon, 'lat': lat,
+                     'pflag': pflag, 'ptype': ptype, 'zbb': zbb,
+                     'bbwidth': bbwidth, 'sfc': sfc, 'quality': quality,
+                     'refl': refl})
+
+    return trmm_data

--- a/notebooks/match3d/wradlib_match_trmm_gpm.ipynb
+++ b/notebooks/match3d/wradlib_match_trmm_gpm.ipynb
@@ -113,9 +113,11 @@
    "source": [
     "# read spaceborn PR data\n",
     "import io_func\n",
-    "pr_data = io_func.read_gpm(gpm_file)\n",
+    "#pr_data = io_func.read_gpm(gpm_file)\n",
+    "pr_data = io_func.read_trmm(trmm_2A23_file, trmm_2A25_file)\n",
     "# read matching GR data\n",
-    "gr_data = wradlib.io.read_generic_hdf5(gr2gpm_file)"
+    "#gr_data = wradlib.io.read_generic_hdf5(gr2gpm_file)\n",
+    "gr_data = wradlib.io.read_generic_hdf5(gr2trmm_file)"
    ]
   },
   {
@@ -136,7 +138,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [],
    "source": [


### PR DESCRIPTION
- Add `read_trmm`-function to `io_func.py` submodule
  + reader handles data like idl-counterpart `read_trmm.pro` and returns dictionary with data

Note: The source data files are hdf4-format and cannot be read with `read_generic_hdf5`. But it turned out that it can be read using `read_generic_netcdf`.